### PR TITLE
allow KEY_FROM_LAYER to be overridden by caller

### DIFF
--- a/tests/bin/runLocal.sh
+++ b/tests/bin/runLocal.sh
@@ -29,7 +29,7 @@ if [ ! -f ~/.wskprops ]; then
     echo "INSECURE_SSL=true" >> ~/.wskprops
 fi
 
-export KEY_FROM_LAYER=true
+export KEY_FROM_LAYER=${KEY_FROM_LAYER-true}
 export PATH=./node_modules/.bin:$PATH
 
 if [ -z "$REDIS_URL" ]; then


### PR DESCRIPTION
tests/bin/runLocal.sh hard-codes `KEY_FROM_LAYER=true`. this PR allows the invoker of runLocal.sh to override this setting