### PR TITLE
fixed app create help menu

### DIFF
--- a/app/plugins/modules/composer/lib/create.js
+++ b/app/plugins/modules/composer/lib/create.js
@@ -37,7 +37,7 @@ Options:
 \t-n|--dry-run   check the given input for validity, do not deploy it
 \t--log-input    log initial input with an echo action. App may run slower 
 \t--log-inline   log inline function output with echo actions. App may run slower
-\t-l|--log-all   log initial input and inline function output. App may run slower
+\t--log-all      log initial input and inline function output. App may run slower
 `
 
 /**


### PR DESCRIPTION
Removed `-l` in the help menu: `--log-all` does not have a shorthand 