### PR TITLE
cancel host set if using prefilled content

### DIFF
--- a/app/plugins/ui/commands/auth.js
+++ b/app/plugins/ui/commands/auth.js
@@ -203,8 +203,14 @@ module.exports = (commandTree, require) => {
                            const argv = slice(argv_without_options, 'set')
                            let host = argv[0] || options.host // the new apihost to use
                            let ignoreCerts = options.ignoreCerts || options.insecureSSL || options.insecure
+
                            if (!host || options.help) {
                                throw new Error('Usage: host set <hostname>')
+                           } else if (host === '<your_api_host>') {
+                               // clicking on the host in the upper right prefills some content;
+                               // if the user hits return, we want the operation to be cancelled
+                               // see shell issue #192
+                               throw new Error('Operation cancelled')
                            }
 
                            //
@@ -212,12 +218,15 @@ module.exports = (commandTree, require) => {
                            // couple of common scenarios. we check for
                            // those here
                            //
-                           if (host === 'bluemix' || host === 'us-south') {
+                           if (host === 'dallas' || host === 'us-south') {
                                // accept a short-hand for the Dallas Bluemix OpenWhisk
                                host = 'https://openwhisk.ng.bluemix.net'
                            } else if (host === 'london' || host === 'eu-gb') {
                                // accept a short-hand for the London Bluemix OpenWhisk
                                host = 'https://openwhisk.eu-gb.bluemix.net'
+                           } else if (host === 'frankfurt' || host === 'eu-de') {
+                               // accept a short-hand for the Frankfurt Bluemix OpenWhisk
+                               host = 'https://openwhisk.eu-de.bluemix.net'
                            } else if (host === 'docker-machine' || host === 'dm' || host === 'mac' || host === 'darwin' || host === 'macos') {
                                // local docker-machine host (this is usually macOS)
                                host = 'http://192.168.99.100:10001'

--- a/tests/tests/passes/02/host.js
+++ b/tests/tests/passes/02/host.js
@@ -46,4 +46,10 @@ describe('host tests', function() {
 
     it('bogus host from /host context', () => cli.do(`set yyy`, this.app)
 	.then(cli.expectOKWithCustom({selector: '', expect: `Before you can proceed, please provide an OpenWhisk auth key, using auth add <AUTH_KEY>` })))
+
+    // clicking on the host in the upper right prefills some content;
+    // if the user hits return, we want the operation to be cancelled
+    // see shell issue #192
+    it('should auto-cancel when using prefilled content', () => cli.do(`host set <your_api_host>`, this.app)
+       .then(cli.expectError(0, 'Operation cancelled')))
 })


### PR DESCRIPTION
also add frankfurt shorthand, and change "bluemix" to "dallas"

Fixes #192 