### PR TITLE
Add command to update shell when a new version is detected 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ app/plugins/.pre-scanned
 .openwhisk-shell
 dump.rdb
 openwhisk
+.idea


### PR DESCRIPTION
when running `fsh version -u`, if a new version is detected, emit a message to copy/paste and upgrade the shell. I didn't go further to actually run the command for you, but at least saving you from typing the command is nice.

Here's a sample output:
```
[ 'Package               Current   Latest ',
  '@ibm-functions/shell  1.3.399  1.3.402',
  'To update, run the following command from the terminal:',
  'npm update @ibm-functions/shell -g' ]
```

Where the last two entries are due to this PR.
I put the `-g` at the end in case it's not desired in some installations.