### PR TITLE
the breadcrumbs for the plugin commands don't have the full name for …

### DIFF
--- a/app/plugins/modules/plugin/usage.js
+++ b/app/plugins/modules/plugin/usage.js
@@ -15,7 +15,7 @@
  */
 
 /** breadcrumb parents */
-const parents = ['plugin']
+const parents = [{ command: 'plugin' }]
 
 /** required parameter: name of installed plugin */
 const installedPlugin = [{ name: 'plugin', docs: 'the name of an installed plugin' }]


### PR DESCRIPTION
…the plugin subtree

Fixes #608