### PR TITLE
make default grid cells a smidgen bigger, to avoid squished inline text

### DIFF
--- a/app/plugins/modules/activation-visualizations/lib/cell.js
+++ b/app/plugins/modules/activation-visualizations/lib/cell.js
@@ -58,7 +58,7 @@ exports.renderCell = (returnTo, cell, activation, isFailure=!activation.response
         fdom.className = 'grid-oops-overlay'
         container.appendChild(fdom)
 
-    } else if (!options || options.zoom > 0) {
+    } else if (!options || options.zoom >= 0) {
         // for larger zoom levels, and only for successful activations,
         // render the latency inside the cell
         const innerLabel = document.createElement('span')

--- a/app/plugins/modules/activation-visualizations/lib/grid.js
+++ b/app/plugins/modules/activation-visualizations/lib/grid.js
@@ -287,7 +287,7 @@ const _drawGrid = (options, {sidecar, leftHeader, rightHeader}, content, groupDa
             }
 
             // and try to make the gridDom mostly squarish
-            gridDom.querySelector('.grid-row').style.maxWidth = `${width * (zoomLevelForDisplay === 0 ? 2.5 : zoomLevelForDisplay === 1 ? 3 : zoomLevelForDisplay === 2 ? 4 : 0.75)}vw`
+            gridDom.querySelector('.grid-row').style.maxWidth = `${width * (zoomLevelForDisplay === 0 ? 2.75 : zoomLevelForDisplay === 1 ? 3 : zoomLevelForDisplay === 2 ? 4 : 0.75)}vw`
 
             let idx = 0
             group.activations.forEach(activation => {

--- a/app/plugins/modules/activation-visualizations/web/css/table.css
+++ b/app/plugins/modules/activation-visualizations/web/css/table.css
@@ -373,8 +373,8 @@
 }*/
 .activation-viz-plugin .grid-cell {
     /* square aspect ratio */
-    width: 2.5vw;
-    height: 2.5vw;
+    width: 2.75vw;
+    height: 2.75vw;
 }
 .activation-viz-plugin .zoom_1 .grid-cell {
     /* square aspect ratio */


### PR DESCRIPTION
Fixes #374