### PR TITLE
fix for top-level help: screenshot wasn't a clickable

### DIFF
--- a/app/plugins/ui/commands/screenshot.js
+++ b/app/plugins/ui/commands/screenshot.js
@@ -20,8 +20,9 @@
  */
 const usage = {
     strict: 'screenshot',
+    command: 'screenshot',
     title: 'Capture screenshot',
-    header: 'Capture a screenshot to the clipboard, optionally specifying which region of the window to capture.',
+    header: 'Capture a screenshot, optionally specifying which region of the window to capture.',
     example: 'screenshot [which]',
     detailedExample: [
         { command: 'screenshot sidecar', docs: 'capture the sidecar contents' },

--- a/tests/tests/passes/02/screenshot.js
+++ b/tests/tests/passes/02/screenshot.js
@@ -49,7 +49,7 @@ describe('Take screenshot', function() {
        .then(cli.expectError(0, 'You requested to screenshot the last REPL output, but this is the first command')))
 
     it('should fail to take screenshot with bogus arg', () => cli.do(`screenshot goober`, this.app)
-       .then(cli.expectError(500, 'Capture a screenshot to the clipboard'))) // part of the usage message
+       .then(cli.expectError(500, 'Capture a screenshot'))) // part of the usage message
 
     it('should take screenshot with no arguments', () => takeScreenshot(this))
     it('should take screenshot full', () => takeScreenshot(this, 'full'))


### PR DESCRIPTION
Fixes #841