### PR TITLE
remove use of ibm.biz URL shortener in let-remote test

### DIFF
--- a/tests/tests/passes/04/let-remote.js
+++ b/tests/tests/passes/04/let-remote.js
@@ -30,7 +30,7 @@ const fs = require('fs'),
           local: 'data/hello.html'
       },
       REMOTE2 = {
-          url: 'http://ibm.biz/openwhisk-shell-demo-html',
+          url: 'https://ibm.box.com/shared/static/zsye0mwai0kce2p6wssltpsi5bfj9dy0.html',
           local: 'data/openwhisk-shell-demo-html'
       },
       actionName = 'foo',


### PR DESCRIPTION
Fixes #1066